### PR TITLE
[2021-02-19][Authorization]용석:사용자 계정 생성 Service

### DIFF
--- a/AuthorizationServer/pom.xml
+++ b/AuthorizationServer/pom.xml
@@ -70,6 +70,12 @@
             <version>${spring-security.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- About Authentication -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/AuthorizationServer/src/main/java/io/example/authorization/config/ApplicationConfig.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/config/ApplicationConfig.java
@@ -1,0 +1,20 @@
+package io.example.authorization.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * @author : choi-ys
+ * @date : 2021/02/19 1:49 오후
+ * @Content : Application 전역에서 사용하는 Bean
+ */
+@Configuration
+public class ApplicationConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder(){
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+}

--- a/AuthorizationServer/src/main/java/io/example/authorization/domain/entity/common/MetaEntity.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/domain/entity/common/MetaEntity.java
@@ -11,11 +11,11 @@ public class MetaEntity {
     private String createdBy;
 
     @Column(name = "created_at")
-    private LocalDateTime createdAt;
+    private LocalDateTime createdAt = LocalDateTime.now();
 
     @Column(name = "updated_by")
     private String updatedBy;
 
     @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
+    private LocalDateTime updatedAt = LocalDateTime.now();
 }

--- a/AuthorizationServer/src/main/java/io/example/authorization/domain/entity/partner/PartnerEntity.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/domain/entity/partner/PartnerEntity.java
@@ -4,6 +4,7 @@ import io.example.authorization.domain.entity.common.MetaEntity;
 import lombok.*;
 
 import javax.persistence.*;
+import java.util.Collections;
 import java.util.Set;
 
 @Entity
@@ -13,7 +14,7 @@ import java.util.Set;
                 @UniqueConstraint(name = "PARTNER_ID_UNIQUE", columnNames = "partner_id")
             }
         )
-@Getter @EqualsAndHashCode(of = "id")
+@Getter @Setter @EqualsAndHashCode(of = "id")
 @Builder @NoArgsConstructor @AllArgsConstructor
 public class PartnerEntity extends MetaEntity {
 
@@ -24,7 +25,7 @@ public class PartnerEntity extends MetaEntity {
     @Column(name = "partner_id", nullable = false, length = 50)
     private String partnerId; // 제휴사 ID : Unique key
 
-    @Column(name = "partner_password", nullable = false, length = 50)
+    @Column(name = "partner_password", nullable = false, length = 100)
     private String partnerPassword; // 제휴사 비밀번호
 
     @Column(name = "partner_email", nullable = false, length = 50)
@@ -53,4 +54,9 @@ public class PartnerEntity extends MetaEntity {
 
     @Enumerated(EnumType.STRING)
     private PartnerStatus partnerStatus; // 파트너 상태
+
+    public void signUp(){
+        this.partnerRoles = Collections.singleton(PartnerRole.FORBIDDEN);
+        this.partnerStatus = PartnerStatus.API_NOT_AVAILABLE;
+    }
 }

--- a/AuthorizationServer/src/main/java/io/example/authorization/domain/entity/partner/PartnerStatus.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/domain/entity/partner/PartnerStatus.java
@@ -6,7 +6,6 @@ package io.example.authorization.domain.entity.partner;
 public enum PartnerStatus {
     API_NOT_AVAILABLE,      // 제휴 진행 전 상태 [기본값] : Client ID / Secret 발급전 API 사용 권한 없는 NEWBIE 권한
     DRAFT,                  // 제휴 진행 전 상태 : 기본적인 API 통신만이 허용된 STARTER 권한
-    PRE_ALLIANCE,           // 제휴 체험 상태 : API 허용량이 제한된 TRIAL 권한
     ALLIANCE,               // 제휴 진행 상태 : 과금방식에 따라 API 허용량이 다른 STANDARD, PREMINUM의 권한
     EXPIRATION,             // 제휴 만료 상태 : FORBIDDEN 권한
     STOP_USING_BY_ADMIN,    // 사내 관리자에 의한 제휴 정지 -> FORBIDDEN 권한

--- a/AuthorizationServer/src/main/java/io/example/authorization/domain/response/common/Error.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/domain/response/common/Error.java
@@ -1,0 +1,19 @@
+package io.example.authorization.domain.response.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter @Setter
+@ToString
+@Builder
+public class Error {
+
+    private int code;
+    private String message;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String detail;
+}

--- a/AuthorizationServer/src/main/java/io/example/authorization/domain/response/common/ProcessingResult.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/domain/response/common/ProcessingResult.java
@@ -1,0 +1,29 @@
+package io.example.authorization.domain.response.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class ProcessingResult<T> {
+
+    private boolean success = true;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T data;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Error error;
+
+    public ProcessingResult(T data) {
+        if(data instanceof Error){
+            this.success = false;
+            this.error = (Error) data;
+        }else{
+            this.data = data;
+        }
+    }
+}

--- a/AuthorizationServer/src/main/java/io/example/authorization/repository/PartnerRepository.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/repository/PartnerRepository.java
@@ -4,4 +4,6 @@ import io.example.authorization.domain.entity.partner.PartnerEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PartnerRepository extends JpaRepository<PartnerEntity, Long> {
+
+    long countByPartnerId(String id);
 }

--- a/AuthorizationServer/src/main/java/io/example/authorization/service/PartnerService.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/service/PartnerService.java
@@ -1,0 +1,58 @@
+package io.example.authorization.service;
+
+import io.example.authorization.domain.entity.partner.PartnerEntity;
+import io.example.authorization.domain.response.common.Error;
+import io.example.authorization.domain.response.common.ProcessingResult;
+import io.example.authorization.repository.PartnerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import static io.example.authorization.service.common.CommonResult.serverError;
+
+/**
+ * @date : 2021/02/19 12:08 오후
+ * @author : choi-ys
+ * @Content : 사용자 계정 처리 Service
+**/
+@Service
+@RequiredArgsConstructor
+public class PartnerService {
+
+    private final PartnerRepository partnerRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    /**
+     * 인증 토큰 발급 대상자인 사용자 계정 생성 로직
+     *  - partnerId 항목 중복 검사
+     *  - 비밀번호 항목 암호화 : passwordEncoder를 이용한 Bcript 암호화
+     *  - 입력값에 의해 결정되는 값 설정 : 사용자의 초기 권한 및 상태
+     *  - DB 저장 및 처리 결과 반환 처리
+     *  - 로직 처리 중 발생하는 예외 반환 처리
+     * @param partnerEntity
+     * @return
+     */
+    public ProcessingResult savePartner(PartnerEntity partnerEntity){
+        if(this.isDuplicatedId(partnerEntity.getPartnerId())){
+            return new ProcessingResult(Error.builder()
+                    .code(-1)
+                    .message("이미 존재하는 ID 입니다.")
+                    .build()
+            );
+        }
+
+        partnerEntity.setPartnerPassword(this.passwordEncoder.encode(partnerEntity.getPartnerPassword()));
+        partnerEntity.signUp();
+
+        try {
+            return new ProcessingResult(this.partnerRepository.save(partnerEntity));
+        } catch (Exception e) {
+            return serverError(e);
+        }
+    }
+
+    private boolean isDuplicatedId(String partnerId){
+        long count = partnerRepository.countByPartnerId(partnerId);
+        return (count == 0) ? false : true;
+    }
+}

--- a/AuthorizationServer/src/main/java/io/example/authorization/service/common/CommonResult.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/service/common/CommonResult.java
@@ -1,0 +1,33 @@
+package io.example.authorization.service.common;
+
+import io.example.authorization.domain.response.common.Error;
+import io.example.authorization.domain.response.common.ProcessingResult;
+
+public class CommonResult {
+
+    /**
+     * ServerError 결과 반환
+     * @param e
+     * @return
+     */
+    public static ProcessingResult serverError(Exception e){
+        return new ProcessingResult(Error.builder()
+                .code(500)
+                .message("요청을 처리하는 과정에서 오류가 발생하였습니다. 관리자에게 문의하세요.")
+                .detail(e.getMessage())
+                .build()
+        );
+    }
+
+    /**
+     * notFound 결과 반환
+     * @return
+     */
+    private ProcessingResult notFound(){
+        return new ProcessingResult(Error.builder()
+                .code(404)
+                .message("요청에 해당하는 데이터가 존재하지 않습니다.")
+                .build()
+        );
+    }
+}

--- a/AuthorizationServer/src/test/java/io/example/authorization/repository/PartnerRepositoryTest.java
+++ b/AuthorizationServer/src/test/java/io/example/authorization/repository/PartnerRepositoryTest.java
@@ -7,14 +7,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 @DataJpaTest
 //@SpringBootTest(webEnvironment = RANDOM_PORT)

--- a/AuthorizationServer/src/test/java/io/example/authorization/service/PartnerServiceTest.java
+++ b/AuthorizationServer/src/test/java/io/example/authorization/service/PartnerServiceTest.java
@@ -1,0 +1,63 @@
+package io.example.authorization.service;
+
+import io.example.authorization.domain.entity.partner.PartnerEntity;
+import io.example.authorization.domain.entity.partner.PartnerRole;
+import io.example.authorization.domain.entity.partner.PartnerStatus;
+import io.example.authorization.domain.response.common.ProcessingResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+/**
+ * @author : choi-ys
+ * @date : 2021/02/19 12:20 오후
+ * @Content : 사용자 계정 관련 TC
+ */
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@DisplayName("Partner Service Test")
+@ActiveProfiles("test")
+class PartnerServiceTest {
+
+    @Autowired PartnerService partnerService;
+    @Autowired PasswordEncoder passwordEncoder;
+
+    @Test
+    @DisplayName("신규 사용자 생성")
+    void savePartner() {
+        // given
+        String partnerId = "user";
+        String partnerPassword = "password";
+        String partnerEmail = "project.log.065@gmail.com";
+        String partnerCompanyName = "naver";
+
+        PartnerEntity partnerEntity = PartnerEntity.builder()
+                .partnerId(partnerId)
+                .partnerPassword(partnerPassword)
+                .partnerEmail(partnerEmail)
+                .partnerCompanyName(partnerCompanyName)
+                .build();
+
+        // when
+        ProcessingResult processingResult = this.partnerService.savePartner(partnerEntity);
+        PartnerEntity savedPartnerEntity = (PartnerEntity) processingResult.getData();
+
+        // then
+        assertThat(processingResult.isSuccess()).isTrue();
+        assertThat(processingResult.getError()).isNull();
+        assertThat(savedPartnerEntity.getPartnerId()).isEqualTo(partnerId);
+        assertThat(passwordEncoder.matches(partnerPassword, savedPartnerEntity.getPartnerPassword())).isTrue();
+        assertThat(savedPartnerEntity.getPartnerEmail()).isEqualTo(partnerEmail);
+        assertThat(savedPartnerEntity.getPartnerCompanyName()).isEqualTo(partnerCompanyName);
+
+        assertThat(savedPartnerEntity.getPartnerRoles()).isEqualTo(Collections.singleton(PartnerRole.FORBIDDEN));
+        assertThat(savedPartnerEntity.getPartnerStatus()).isEqualTo(PartnerStatus.API_NOT_AVAILABLE);
+    }
+}

--- a/AuthorizationServer/src/test/resources/application-test.yml
+++ b/AuthorizationServer/src/test/resources/application-test.yml
@@ -1,0 +1,28 @@
+server:
+  port: 8080
+
+spring:
+  h2:
+    console:
+      enabled: true
+      settings:
+        web-allow-others: true
+  datasource:
+    url: jdbc:h2:mem:test_db
+    driver-class-name: org.h2.Driver
+    username: sa
+  jpa:
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        use_sql_comments: true
+
+logging:
+  level:
+    org:
+      hibernate:
+        type:
+          descriptor:
+            sql:
+              BasicBinder: trace


### PR DESCRIPTION
 - 암호화를 위한 Spring Security 의존성 추가 및 PasswordEncoder Bean 등록
 - Test Case에서 사용되는 InMemory H2 Database 설정 추가
 - PartnerService.savePartner() : 인증 토큰 발급 대상자인 사용자 계정 생성 로직
   - partnerId 항목 중복 검사
   - 비밀번호 항목 암호화 : passwordEncoder를 이용한 Bcript 암호화
   - 입력값에 의해 결정되는 값 설정 : 사용자의 초기 권한 및 상태
   - DB 저장 및 처리 결과 반환 처리
   - 로직 처리 중 발생하는 예외 반환 처리
 - PartnerServiceTest.savePartner() : 사용자 계정 생성 로직 Test Case
 - ProcessingResult : 처리 결과 객체 생성
 - CommonResult : 공통 결과 반환 부 생성