### PR TITLE
[2021-02-24][Authorization]용석:사용자 계정 생성 API #2

### DIFF
--- a/AuthorizationServer/src/main/java/io/example/authorization/config/WebSecurityConfig.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/config/WebSecurityConfig.java
@@ -19,7 +19,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .csrf()
                     .disable() // 토큰 발급 시 요청 Method인 POST 요청 임시 허용 설정 추가
                 .authorizeRequests()
-                    .antMatchers("/oauth/**", "/client/callback", "/h2-console/*").permitAll()
+                    .antMatchers("/oauth/**", "/client/callback", "/h2-console/*", "/api/partner/**").permitAll()
                     .anyRequest().authenticated()
                 .and()
                 .httpBasic();

--- a/AuthorizationServer/src/main/java/io/example/authorization/constants/MediaTypes.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/constants/MediaTypes.java
@@ -1,0 +1,5 @@
+package io.example.authorization.constants;
+
+public interface MediaTypes {
+    String HAL_JSON_UTF8_VALUE = "application/json+hal;charset=UTF-8";
+}

--- a/AuthorizationServer/src/main/java/io/example/authorization/controller/PartnerController.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/controller/PartnerController.java
@@ -1,0 +1,31 @@
+package io.example.authorization.controller;
+
+import io.example.authorization.domain.dto.request.CreatePartner;
+import io.example.authorization.service.PartnerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static io.example.authorization.constants.MediaTypes.HAL_JSON_UTF8_VALUE;
+
+@RestController
+@RequestMapping(value = "/api/partner", produces = HAL_JSON_UTF8_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
+@RequiredArgsConstructor
+public class PartnerController {
+
+    private final PartnerService partnerService;
+
+    @PostMapping
+    public ResponseEntity createPartner(CreatePartner createPartner){
+        String msg = "요청이 성공적으로 처리 되었습니다.";
+        if(createPartner != null){
+            return ResponseEntity.ok(msg);
+        }else{
+            msg = "잘못된 요청입니다. 다시 시도해 주세요";
+            return ResponseEntity.badRequest().body(msg);
+        }
+    }
+}

--- a/AuthorizationServer/src/main/java/io/example/authorization/domain/dto/request/CreatePartner.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/domain/dto/request/CreatePartner.java
@@ -1,0 +1,16 @@
+package io.example.authorization.domain.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class CreatePartner {
+
+    private String partnerId;
+
+    private String partnerPassword;
+
+    private String partnerEmail;
+
+    private String partnerCompanyName;
+}

--- a/AuthorizationServer/src/main/java/io/example/authorization/domain/dto/response/common/Error.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/domain/dto/response/common/Error.java
@@ -1,4 +1,4 @@
-package io.example.authorization.domain.response.common;
+package io.example.authorization.domain.dto.response.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;

--- a/AuthorizationServer/src/main/java/io/example/authorization/domain/dto/response/common/ProcessingResult.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/domain/dto/response/common/ProcessingResult.java
@@ -1,4 +1,4 @@
-package io.example.authorization.domain.response.common;
+package io.example.authorization.domain.dto.response.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;

--- a/AuthorizationServer/src/main/java/io/example/authorization/service/PartnerService.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/service/PartnerService.java
@@ -1,8 +1,8 @@
 package io.example.authorization.service;
 
 import io.example.authorization.domain.entity.partner.PartnerEntity;
-import io.example.authorization.domain.response.common.Error;
-import io.example.authorization.domain.response.common.ProcessingResult;
+import io.example.authorization.domain.dto.response.common.Error;
+import io.example.authorization.domain.dto.response.common.ProcessingResult;
 import io.example.authorization.repository.PartnerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;

--- a/AuthorizationServer/src/main/java/io/example/authorization/service/common/CommonResult.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/service/common/CommonResult.java
@@ -1,7 +1,7 @@
 package io.example.authorization.service.common;
 
-import io.example.authorization.domain.response.common.Error;
-import io.example.authorization.domain.response.common.ProcessingResult;
+import io.example.authorization.domain.dto.response.common.Error;
+import io.example.authorization.domain.dto.response.common.ProcessingResult;
 
 public class CommonResult {
 

--- a/AuthorizationServer/src/test/java/io/example/authorization/controller/PartnerControllerTest.java
+++ b/AuthorizationServer/src/test/java/io/example/authorization/controller/PartnerControllerTest.java
@@ -1,0 +1,60 @@
+package io.example.authorization.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.example.authorization.domain.dto.request.CreatePartner;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static io.example.authorization.constants.MediaTypes.HAL_JSON_UTF8_VALUE;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DisplayName("Partner API")
+class PartnerControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("파트너 계정 생성 API")
+    public void createPartner() throws Exception {
+        // Given
+        String partnerId = "project062";
+        String partnerPassword = "password";
+        String partnerEmail = "project.log.062@gmail.com";
+        String partnerCompanyName = "주식회사 네이버";
+
+        CreatePartner createPartner = new CreatePartner();
+        createPartner.setPartnerId(partnerId);
+        createPartner.setPartnerPassword(partnerPassword);
+        createPartner.setPartnerEmail(partnerEmail);
+        createPartner.setPartnerCompanyName(partnerCompanyName);
+
+        // When
+        String urlTemplate = "/api/partner";
+        ResultActions resultActions = this.mockMvc.perform(post(urlTemplate)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(HAL_JSON_UTF8_VALUE)
+                .content(this.objectMapper.writeValueAsBytes(createPartner))
+        );
+
+        // Then
+        resultActions.andDo(print())
+                .andExpect(status().isOk())
+        ;
+    }
+}

--- a/AuthorizationServer/src/test/java/io/example/authorization/service/PartnerServiceTest.java
+++ b/AuthorizationServer/src/test/java/io/example/authorization/service/PartnerServiceTest.java
@@ -3,7 +3,7 @@ package io.example.authorization.service;
 import io.example.authorization.domain.entity.partner.PartnerEntity;
 import io.example.authorization.domain.entity.partner.PartnerRole;
 import io.example.authorization.domain.entity.partner.PartnerStatus;
-import io.example.authorization.domain.response.common.ProcessingResult;
+import io.example.authorization.domain.dto.response.common.ProcessingResult;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
- 사용자 정보 생성 API 요청 수신 Controller 생성
- hal+json 형식의 응답 Type 추가 : application/json+hal;charset=UTF-8
- 사용자 정보 생성 요청 객체 정의
- 사용자 정보 생성 API TC 작성
- WebSecurityConfig : 사용자 정보 생성 API 허용 설정 추가