### PR TITLE
[2021-03-01][Authorization]용석:DB의 사용자 정보와 UserDetailsService를 이용한 Authentication 설정

### DIFF
--- a/AuthorizationServer/src/main/java/io/example/authorization/config/WebSecurityConfig.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/config/WebSecurityConfig.java
@@ -1,5 +1,7 @@
 package io.example.authorization.config;
 
+import io.example.authorization.service.PartnerService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -7,9 +9,11 @@ import org.springframework.security.config.annotation.authentication.builders.Au
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     // Http 요청에 대한 보안 설정
@@ -25,13 +29,14 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .httpBasic();
     }
 
-    // InMemory환경에서 Token발급 대상인 사용자 정보 설정 추가
+    private final PartnerService partnerService;
+    private final PasswordEncoder passwordEncoder;
+
+    // DB의 사용자 정보를 이용한 인증 정보 설정
     @Override
     protected void configure(AuthenticationManagerBuilder auth) throws Exception {
-        auth.inMemoryAuthentication()
-                .withUser("user")
-                .password("{noop}password")
-                .roles("USER")
+        auth.userDetailsService(partnerService)
+                .passwordEncoder(passwordEncoder)
         ;
     }
 

--- a/AuthorizationServer/src/main/java/io/example/authorization/repository/PartnerRepository.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/repository/PartnerRepository.java
@@ -3,7 +3,11 @@ package io.example.authorization.repository;
 import io.example.authorization.domain.entity.partner.PartnerEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PartnerRepository extends JpaRepository<PartnerEntity, Long> {
 
     long countByPartnerId(String id);
+    Optional<PartnerEntity> findByPartnerId(String partnerId);
+    Optional<PartnerEntity> findByPartnerNo(long partnerNo);
 }

--- a/AuthorizationServer/src/main/java/io/example/authorization/service/PartnerService.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/service/PartnerService.java
@@ -3,10 +3,21 @@ package io.example.authorization.service;
 import io.example.authorization.domain.entity.partner.PartnerEntity;
 import io.example.authorization.domain.dto.response.common.Error;
 import io.example.authorization.domain.dto.response.common.ProcessingResult;
+import io.example.authorization.domain.entity.partner.PartnerRole;
 import io.example.authorization.repository.PartnerRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static io.example.authorization.service.common.CommonResult.serverError;
 
@@ -17,7 +28,7 @@ import static io.example.authorization.service.common.CommonResult.serverError;
 **/
 @Service
 @RequiredArgsConstructor
-public class PartnerService {
+public class PartnerService implements UserDetailsService {
 
     private final PartnerRepository partnerRepository;
     private final PasswordEncoder passwordEncoder;
@@ -54,5 +65,43 @@ public class PartnerService {
     private boolean isDuplicatedId(String partnerId){
         long count = partnerRepository.countByPartnerId(partnerId);
         return (count == 0) ? false : true;
+    }
+
+    /**
+     * Application에서 정의한 Account domain을 Spring security에서 정의한 UsertDetail Interface로 변환
+     * @param partnerId
+     * @return
+     * @throws UsernameNotFoundException
+     */
+    @Override
+    public UserDetails loadUserByUsername(String partnerId) throws UsernameNotFoundException {
+        PartnerEntity partnerAccountEntity = partnerRepository.findByPartnerId(partnerId)
+                /**
+                 * 요청 파라미터에 해당하는 Account 객체 조회 실패 시 오류 반환 처리
+                 * - userName(account.email)에 해당 하는 Account 객체 조회 실패 시 Null을 반환 하므로
+                 * - Srping security의 UsernameNotFoundException객체를 통해 정의된 오류를 반환한다.
+                 */
+                .orElseThrow(() -> new UsernameNotFoundException(partnerId));
+
+        /**
+         * Srping security의 User객체를 이용하여 MemberEntity객체를 UserDetails 객체로 변환
+         *  - UserDetails interface로 객체 변환 처리를 구현할 경우 모든 메소드를 구현 해야하므로,
+         *  - UserDetails의 User객체를 이용하여 MemberEntity 체를 Spring Security의 UserDetails 객체로 변환한다.
+         */
+        return new User(partnerAccountEntity.getPartnerId(),
+                partnerAccountEntity.getPartnerPassword(),
+                this.roleToAuthorities(partnerAccountEntity.getPartnerRoles())
+        );
+    }
+
+    /**
+     * Set으로 정의된 Role을 Collection Type으로 변환
+     * @param roles
+     * @return
+     */
+    private Collection<? extends GrantedAuthority> roleToAuthorities(Set<PartnerRole> roles) {
+        return roles.stream()
+                .map(role -> new SimpleGrantedAuthority("ROLE_" + role.name()))
+                .collect(Collectors.toSet());
     }
 }

--- a/AuthorizationServer/src/main/resources/schema.sql
+++ b/AuthorizationServer/src/main/resources/schema.sql
@@ -1,0 +1,15 @@
+create table IF NOT EXISTS oauth_access_token (
+  token_id VARCHAR(256),
+  token TEXT,
+  authentication_id VARCHAR(256) PRIMARY KEY,
+  user_name VARCHAR(256),
+  client_id VARCHAR(256),
+  authentication TEXT,
+  refresh_token VARCHAR(256)
+);
+
+create table IF NOT EXISTS oauth_refresh_token (
+  token_id VARCHAR(256),
+  token TEXT,
+  authentication TEXT
+);

--- a/AuthorizationServer/src/test/java/io/example/authorization/config/AuthorizationConfigTest.java
+++ b/AuthorizationServer/src/test/java/io/example/authorization/config/AuthorizationConfigTest.java
@@ -1,11 +1,17 @@
 package io.example.authorization.config;
 
+import io.example.authorization.common.BaseTest;
+import io.example.authorization.domain.dto.request.CreatePartner;
+import io.example.authorization.domain.entity.partner.PartnerEntity;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -16,23 +22,69 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest(webEnvironment = RANDOM_PORT)
-@AutoConfigureMockMvc
+//@SpringBootTest(webEnvironment = RANDOM_PORT)
+//@AutoConfigureMockMvc
 @DisplayName("Token API")
-class AuthorizationConfigTest {
+@Slf4j
+class AuthorizationConfigTest extends BaseTest{
+
+    @Autowired
+    ModelMapper modelMapper;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
 
     @Autowired
     private MockMvc mockMvc;
 
     @Test
     @DisplayName("인증 토큰 발급 : Password Type의 인증 토큰 발급")
-    public void getAutorizationCodeAndAccessToken() throws Exception {
+    public void issuedAccessTokenToInMemoryUser() throws Exception {
         //given
         String urlTemplate = "/oauth/token";
         String clientId = "testClientId";
         String clientSecret = "testClientSecret";
         String username = "user";
         String password = "password";
+
+        //when
+        ResultActions resultActions = this.mockMvc.perform(post(urlTemplate)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .with(httpBasic(clientId, clientSecret))
+                .param("username", username)
+                .param("password", password)
+                .param("grant_type", "password")
+        );
+
+        //then
+        resultActions.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("access_token").exists())
+                .andExpect(jsonPath("token_type").exists())
+                .andExpect(jsonPath("refresh_token").exists())
+                .andExpect(jsonPath("expires_in").exists())
+                .andExpect(jsonPath("scope").exists())
+        ;
+    }
+
+    @Test
+    @DisplayName("인증 토큰 발급 : DB의 인증된 사용자 정보를 이용한 Token 발급")
+    public void issuedAccessTokenToDatabaseUser() throws Exception {
+        //given
+        CreatePartner createPartner = this.partnerGenerator.createPartner();
+        PartnerEntity partnerEntity = this.modelMapper.map(createPartner, PartnerEntity.class);
+        partnerEntity.setPartnerPassword(this.passwordEncoder.encode(partnerEntity.getPartnerPassword()));
+        partnerEntity.signUp();
+        PartnerEntity savedPartnerEntity = this.partnerRepository.save(partnerEntity);
+
+        System.out.println(savedPartnerEntity.getPartnerPassword());
+
+        String urlTemplate = "/oauth/token";
+        String clientId = "testClientId";
+        String clientSecret = "testClientSecret";
+        String username = createPartner.getPartnerId();
+        String password = createPartner.getPartnerPassword();
 
         //when
         ResultActions resultActions = this.mockMvc.perform(post(urlTemplate)

--- a/AuthorizationServer/src/test/java/io/example/authorization/generator/PartnerGenerator.java
+++ b/AuthorizationServer/src/test/java/io/example/authorization/generator/PartnerGenerator.java
@@ -6,6 +6,7 @@ import io.example.authorization.repository.PartnerRepository;
 import org.junit.jupiter.api.Disabled;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 /**
  * @author : choi-ys
@@ -17,6 +18,9 @@ public class PartnerGenerator {
 
     @Autowired
     ModelMapper modelMapper;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
 
     @Autowired
     PartnerRepository partnerRepository;
@@ -39,6 +43,7 @@ public class PartnerGenerator {
     public PartnerEntity buildSignUpPartnerEntity(){
         CreatePartner createPartner = this.createPartner();
         PartnerEntity partnerEntity = this.modelMapper.map(createPartner, PartnerEntity.class);
+        partnerEntity.setPartnerPassword(this.passwordEncoder.encode(partnerEntity.getPartnerPassword()));
         partnerEntity.signUp();
         return partnerEntity;
     }

--- a/AuthorizationServer/src/test/java/io/example/authorization/service/PartnerServiceTest.java
+++ b/AuthorizationServer/src/test/java/io/example/authorization/service/PartnerServiceTest.java
@@ -4,13 +4,17 @@ import io.example.authorization.domain.entity.partner.PartnerEntity;
 import io.example.authorization.domain.entity.partner.PartnerRole;
 import io.example.authorization.domain.entity.partner.PartnerStatus;
 import io.example.authorization.domain.dto.response.common.ProcessingResult;
+import io.example.authorization.generator.PartnerGenerator;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 
+import javax.annotation.Resource;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,7 +28,11 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @DisplayName("Partner Service Test")
 @ActiveProfiles("test")
+@Import(PartnerGenerator.class)
 class PartnerServiceTest {
+
+    @Resource
+    protected  PartnerGenerator partnerGenerator;
 
     @Autowired PartnerService partnerService;
     @Autowired PasswordEncoder passwordEncoder;
@@ -59,5 +67,20 @@ class PartnerServiceTest {
 
         assertThat(savedPartnerEntity.getPartnerRoles()).isEqualTo(Collections.singleton(PartnerRole.FORBIDDEN));
         assertThat(savedPartnerEntity.getPartnerStatus()).isEqualTo(PartnerStatus.API_NOT_AVAILABLE);
+    }
+
+    @Test
+    @DisplayName("UserDetailSevice의 loadUserByUsername 이용한 User 정보 조회")
+    public void loadUserByUsername(){
+        // Given
+        PartnerEntity savedPartnerEntity = this.partnerGenerator.savedPartnerEntity();
+        String savedPartnerId = savedPartnerEntity.getPartnerId();
+
+        // When
+        UserDetails userDetails = this.partnerService.loadUserByUsername(savedPartnerId);
+
+        // Then
+        assertThat(userDetails.getUsername()).isEqualTo(savedPartnerId);
+        assertThat(userDetails.getPassword()).isEqualTo(savedPartnerEntity.getPartnerPassword());
     }
 }


### PR DESCRIPTION
 - Authentication설정 시 InMemory환경의 사용자 정보가 아닌 DB의 사용자 정보를 이용한 설정
   - Spring Security의 UserDetailsService를 이용한 DB의 사용자 정보 조회 및 Authentication 설정
 - Test
   - UserDetailsService를 이용한 DB의 사용자 정보 조회
   - DB에 저장된 사용자에 인증 토큰 발급 Test