### PR TITLE
[2021-03-03][Authorization]용석:클라이언트 정보 발급 #1

### DIFF
--- a/AuthorizationServer/src/main/java/io/example/authorization/domain/entity/partner/ClientEntity.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/domain/entity/partner/ClientEntity.java
@@ -1,0 +1,85 @@
+package io.example.authorization.domain.entity.partner;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.example.authorization.domain.entity.common.MetaEntity;
+import lombok.*;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import javax.persistence.*;
+import java.util.*;
+
+@Entity
+@Table(
+        name = "tb_client"
+        , uniqueConstraints = {
+                @UniqueConstraint(name = "CLIENT_ID_UNIQUE", columnNames = "client_id")
+            }
+        )
+@Getter @Setter @EqualsAndHashCode(of = "clientId")
+@Builder @NoArgsConstructor @AllArgsConstructor
+public class ClientEntity extends MetaEntity {
+
+    @Id
+    @Column(name = "client_id")
+    private String clientId;
+
+    @Column(name = "resource_ids")
+    private String resourceIds;
+
+    @Column(name = "client_secret")
+    private String clientSecret;
+
+    private String scope;
+
+    @JsonIgnore
+    @Column(name = "authorized_grant_types")
+    private String authorizedGrantTypes;
+
+    private String authorities;
+
+    @JsonIgnore
+    @Column(name = "access_token_validity")
+    private int accessTokenValidity;
+
+    @JsonIgnore
+    @Column(name = "refresh_token_validity")
+    private int refreshTokenValidity;
+
+    @JsonIgnore
+    @Column(name = "additional_information")
+    private String additionalInformation;
+
+    @JsonIgnore
+    @Column(name = "auto_approve")
+    private boolean autoApprove;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(
+            name = "partner_no"
+            , nullable = false
+            , foreignKey = @ForeignKey(name = "TB_CLIENT_PARTNER_NO_FOREIGN_KEY")
+    )
+    private PartnerEntity partnerEntity;
+
+    /**
+     * 특정 회원에 클라이언트 정보 발급
+     * @param partnerEntity
+     */
+    public void setPublishedClientInfo(PartnerEntity partnerEntity){
+        this.clientId = UUID.randomUUID().toString();
+
+        PasswordEncoder passwordEncoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
+        this.clientSecret = passwordEncoder.encode(clientId);
+
+        this.scope = "read";
+        this.authorizedGrantTypes = "password,refresh_token";
+        this.authorities = PartnerRole.STARTER.name();
+        this.accessTokenValidity = 43200; // 12시간
+        this.refreshTokenValidity = 86400; // 24시간
+
+        partnerEntity.publishedClientInfo();
+        partnerEntity.setClientEntity(this);
+        this.partnerEntity = partnerEntity;
+    }
+}

--- a/AuthorizationServer/src/main/java/io/example/authorization/repository/ClientRepository.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/repository/ClientRepository.java
@@ -1,0 +1,12 @@
+package io.example.authorization.repository;
+
+import io.example.authorization.domain.entity.partner.ClientEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * @author : choi-ys
+ * @date : 2021/03/02 12:14 오후
+ * @Content : ClientEntity객체와 해당 Entity객체에 명시된 DB Table을 연동하는 Repository
+ */
+public interface ClientRepository extends JpaRepository<ClientEntity, String> {
+}

--- a/AuthorizationServer/src/test/java/io/example/authorization/repository/ClientRepositoryTest.java
+++ b/AuthorizationServer/src/test/java/io/example/authorization/repository/ClientRepositoryTest.java
@@ -1,0 +1,110 @@
+package io.example.authorization.repository;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.example.authorization.common.BaseTest;
+import io.example.authorization.domain.dto.request.partner.CreatePartner;
+import io.example.authorization.domain.dto.response.common.ProcessingResult;
+import io.example.authorization.domain.entity.partner.ClientEntity;
+import io.example.authorization.domain.entity.partner.PartnerEntity;
+import io.example.authorization.domain.entity.partner.PartnerRole;
+import io.example.authorization.generator.PartnerGenerator;
+import io.example.authorization.service.PartnerService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import javax.annotation.Resource;
+import javax.transaction.Transactional;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author : choi-ys
+ * @date : 2021/03/02 5:03 오후
+ * @Content : ClientRepository를 이용한 ClientEntity TEST
+ */
+@Slf4j
+class ClientRepositoryTest extends BaseTest {
+
+    @Resource PartnerGenerator partnerGenerator;
+    @Autowired PartnerService partnerService;
+    @Resource ClientRepository clientRepository;
+
+    @Test
+    @DisplayName("[Create]특정 사용자의 클라이언트 정보 생성")
+    @Transactional
+    public void createClientEntity() throws JsonProcessingException {
+        // Given : 클라이언트 정보를 발급할 PartnerEntity 생성
+        CreatePartner createPartner = this.partnerGenerator.createPartner();
+        ProcessingResult savePartnerProcessingResult = this.partnerService.savePartner(createPartner);
+        assertThat(savePartnerProcessingResult.isSuccess()).isTrue();
+        PartnerEntity savedPartnerEntity = (PartnerEntity) savePartnerProcessingResult.getData();
+
+        // Given : 특정회원에 클라이언트 정보 발급
+        ClientEntity clientEntity = this.buildClientEntity();
+        clientEntity.setPublishedClientInfo(savedPartnerEntity);
+
+        // When : 발급된 클라이언트 정보 저장
+        ClientEntity savedClientEntity = this.clientRepository.save(clientEntity);
+
+        // Then : 입력값과 초기값 설정이 필요한 항목의 초기화 여부 확인
+        assertThat(savedClientEntity.getClientId()).isEqualTo(clientEntity.getClientId());
+        assertThat(savedClientEntity.getClientSecret()).isEqualTo(clientEntity.getClientSecret());
+        assertThat(savedClientEntity.getResourceIds()).isEqualTo(clientEntity.getResourceIds());
+        assertThat(savedClientEntity.getScope()).isEqualTo(clientEntity.getScope());
+        assertThat(savedClientEntity.getAuthorizedGrantTypes()).isEqualTo(clientEntity.getAuthorizedGrantTypes());
+        assertThat(savedClientEntity.getAuthorities()).isEqualTo(clientEntity.getAuthorities());
+        assertThat(savedClientEntity.getAccessTokenValidity()).isEqualTo(clientEntity.getAccessTokenValidity());
+        assertThat(savedClientEntity.getRefreshTokenValidity()).isEqualTo(clientEntity.getRefreshTokenValidity());
+        assertThat(savedClientEntity.getPartnerEntity()).isEqualTo(savedPartnerEntity);
+    }
+
+    @Test
+    @DisplayName("[Create]특정 사용자 정보가 없는 클라리언트 정보 생성")
+    public void createClientEntity_NoExistsPartnerRequest(){
+        // Given
+        ClientEntity clientEntity = this.buildClientEntity();
+
+        // When
+        Exception exception = Assertions.assertThrows(DataIntegrityViolationException.class, () -> clientRepository.save(clientEntity));
+
+        System.out.println("Exception : " + exception.getClass().getName());
+        System.out.println("getMessage() : " + exception.getMessage());
+        exception.printStackTrace();
+    }
+
+    @Disabled
+    private ClientEntity buildClientEntity(){
+        String clientId = UUID.randomUUID().toString();
+        PasswordEncoder passwordEncoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
+        String clientSecret = passwordEncoder.encode(clientId);
+        String resourceIds = "naver";
+
+        String scope = "read";
+        String authorizedGrantTypes = "password,refresh_token";
+        String authorities = PartnerRole.STARTER.name();
+        int accessTokenValidity = 43200; // 12시간
+        int refreshTokenValidity = 86400; // 24시간
+
+        ClientEntity clientEntity = ClientEntity.builder()
+                .clientId(clientId)
+                .clientSecret(clientSecret)
+                .resourceIds(resourceIds)
+                .scope(scope)
+                .authorizedGrantTypes(authorizedGrantTypes)
+                .authorities(authorities)
+                .accessTokenValidity(accessTokenValidity)
+                .refreshTokenValidity(refreshTokenValidity)
+                .build();
+
+        return clientEntity;
+    }
+}


### PR DESCRIPTION
 - 클라이언트 도메인 설계 및 발급 처리
   - 클라이언트 정보를 표현하는 Entity 객체 설계 및 정의
   - 설계한 Entity 객체와 DB Table을 연동하는 Repository 정의
   - 특정 사용자에 클라이언트 정보 발급 시 로직 처리
     - 클라이언트 발급 시 초기값 설정이 필요한 항목의 값 설정
     - 클라이언트 발급 시 사용자 권한 및 상태 변경
   - TEST : DB에 저장된 특정 사용자 정보에 클라이언트 정보 발급 및 발급 시 로 처리 여부