### PR TITLE
[2021-03-03][Authorization]용석:클라이언트 정보 발급 #2

### DIFF
--- a/AuthorizationServer/src/main/java/io/example/authorization/controller/PartnerController.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/controller/PartnerController.java
@@ -1,10 +1,7 @@
 package io.example.authorization.controller;
 
-import io.example.authorization.controller.common.CommonResponseEntity;
-import io.example.authorization.domain.dto.request.CreatePartner;
+import io.example.authorization.domain.dto.request.partner.CreatePartner;
 import io.example.authorization.domain.dto.response.common.ProcessingResult;
-import io.example.authorization.domain.dto.response.resource.ErrorsEntityModel;
-import io.example.authorization.domain.dto.response.resource.ProcessingResultEntityModel;
 import io.example.authorization.domain.entity.partner.PartnerEntity;
 import io.example.authorization.service.PartnerService;
 import lombok.RequiredArgsConstructor;

--- a/AuthorizationServer/src/main/java/io/example/authorization/domain/dto/request/partner/CreatePartner.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/domain/dto/request/partner/CreatePartner.java
@@ -1,4 +1,4 @@
-package io.example.authorization.domain.dto.request;
+package io.example.authorization.domain.dto.request.partner;
 
 import lombok.*;
 

--- a/AuthorizationServer/src/main/java/io/example/authorization/domain/entity/partner/PartnerEntity.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/domain/entity/partner/PartnerEntity.java
@@ -14,7 +14,7 @@ import java.util.Set;
                 @UniqueConstraint(name = "PARTNER_ID_UNIQUE", columnNames = "partner_id")
             }
         )
-@Getter @Setter @EqualsAndHashCode(of = "id")
+@Getter @Setter
 @Builder @NoArgsConstructor @AllArgsConstructor
 public class PartnerEntity extends MetaEntity {
 
@@ -34,18 +34,12 @@ public class PartnerEntity extends MetaEntity {
     @Column(name = "partner_company_name",nullable = false, length = 50)
     private String partnerCompanyName; // 제휴사 명
 
-    @Column(name = "client_id", nullable = true, length = 100)
-    private String clientId; // Token 발급을 위한 Client ID
-
-    @Column(name = "client_secret", nullable = true, length = 100)
-    private String clientSecret; // Token 발급을 위한 Client Secret
-
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(
             name = "tb_partner_role"
             , joinColumns = @JoinColumn(
                     name = "partner_no"
-                    , foreignKey = @ForeignKey(name = "PARTNER_NO_FOREIGN_KEY")
+                    , foreignKey = @ForeignKey(name = "TB_PARTNER_ROLE_PARTNER_NO_FOREIGN_KEY")
             )
     )
     @Enumerated(EnumType.STRING)
@@ -55,8 +49,16 @@ public class PartnerEntity extends MetaEntity {
     @Enumerated(EnumType.STRING)
     private PartnerStatus partnerStatus; // 파트너 상태
 
+    @OneToOne(mappedBy = "partnerEntity")
+    private ClientEntity clientEntity;
+
     public void signUp(){
         this.partnerRoles = Collections.singleton(PartnerRole.FORBIDDEN);
         this.partnerStatus = PartnerStatus.API_NOT_AVAILABLE;
+    }
+
+    public void publishedClientInfo(){
+        this.partnerRoles = Collections.singleton(PartnerRole.STARTER);
+        this.partnerStatus = PartnerStatus.DRAFT;
     }
 }

--- a/AuthorizationServer/src/main/java/io/example/authorization/service/common/CommonResult.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/service/common/CommonResult.java
@@ -23,7 +23,7 @@ public class CommonResult {
      * notFound 결과 반환
      * @return
      */
-    private ProcessingResult notFound(){
+    public static ProcessingResult notFound(){
         return new ProcessingResult(Error.builder()
                 .code(404)
                 .message("요청에 해당하는 데이터가 존재하지 않습니다.")

--- a/AuthorizationServer/src/test/java/io/example/authorization/controller/PartnerControllerTest.java
+++ b/AuthorizationServer/src/test/java/io/example/authorization/controller/PartnerControllerTest.java
@@ -2,7 +2,7 @@ package io.example.authorization.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.example.authorization.common.BaseTest;
-import io.example.authorization.domain.dto.request.CreatePartner;
+import io.example.authorization.domain.dto.request.partner.CreatePartner;
 import io.example.authorization.domain.entity.partner.PartnerStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/AuthorizationServer/src/test/java/io/example/authorization/domain/entity/partner/PartnerEntityTest.java
+++ b/AuthorizationServer/src/test/java/io/example/authorization/domain/entity/partner/PartnerEntityTest.java
@@ -1,7 +1,6 @@
-package io.example.authorization.domain.partner.entity;
+package io.example.authorization.domain.entity.partner;
 
-import io.example.authorization.domain.dto.request.CreatePartner;
-import io.example.authorization.domain.entity.partner.PartnerEntity;
+import io.example.authorization.domain.dto.request.partner.CreatePartner;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.modelmapper.ModelMapper;

--- a/AuthorizationServer/src/test/java/io/example/authorization/generator/PartnerGenerator.java
+++ b/AuthorizationServer/src/test/java/io/example/authorization/generator/PartnerGenerator.java
@@ -1,6 +1,6 @@
 package io.example.authorization.generator;
 
-import io.example.authorization.domain.dto.request.CreatePartner;
+import io.example.authorization.domain.dto.request.partner.CreatePartner;
 import io.example.authorization.domain.entity.partner.PartnerEntity;
 import io.example.authorization.repository.PartnerRepository;
 import org.junit.jupiter.api.Disabled;


### PR DESCRIPTION
 - 클라이언트 도메인 설계로 인해 발생한 수정 사항 적용
   - PartnerEntity
     - PartnerEntity <-> ClientEntity 양방향 Mapping 설정
     - 클라이언트 정보 발급 시 사용자 권한 및 상태 변경 처리 추가
     - 중복된 외래키 제약조건 명 수정
     - 미사용 코드 삭제
   - CreatePartner, PartnerEntityTest : Package 경로 수정
   - 그 외 코드 수정으로 인한 변경 파일 커밋