### PR TITLE
[2021-03-03][Authorization]용석:클라이언트 정보 발급 #4

### DIFF
--- a/AuthorizationServer/src/main/java/io/example/authorization/domain/dto/request/partner/CreatePartner.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/domain/dto/request/partner/CreatePartner.java
@@ -6,6 +6,11 @@ import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 
+/**
+ * @date : 2021/03/04 6:32 오후
+ * @author : choi-ys
+ * @Content : 사용자 생성 요청 정보
+**/
 @Getter @Setter
 public class CreatePartner {
 

--- a/AuthorizationServer/src/main/java/io/example/authorization/domain/dto/request/partner/IssueClient.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/domain/dto/request/partner/IssueClient.java
@@ -1,0 +1,21 @@
+package io.example.authorization.domain.dto.request.partner;
+
+import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+/**
+ * @author : choi-ys
+ * @date : 2021/03/04 11:29 오전
+ * @Content : 클라이언트 발급 요청 정보
+ */
+@Getter @Setter
+public class IssueClient {
+
+    private long partnerNo;
+
+    @NotBlank(message = "서비스 이름을 입력하세요")
+    @Size(min = 1, max = 25, message = "서비스 이름은 1 ~ 25자 이내로 입력 가능합니다.")
+    private String resourceIds;
+}

--- a/AuthorizationServer/src/main/java/io/example/authorization/domain/entity/partner/ClientEntity.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/domain/entity/partner/ClientEntity.java
@@ -16,7 +16,7 @@ import java.util.*;
                 @UniqueConstraint(name = "CLIENT_ID_UNIQUE", columnNames = "client_id")
             }
         )
-@Getter @Setter @EqualsAndHashCode(of = "clientId")
+@Getter @Setter
 @Builder @NoArgsConstructor @AllArgsConstructor
 public class ClientEntity extends MetaEntity {
 
@@ -63,8 +63,8 @@ public class ClientEntity extends MetaEntity {
     private PartnerEntity partnerEntity;
 
     /**
-     * 특정 회원에 클라이언트 정보 발급
-     * @param partnerEntity
+     * 특정 사용자에 클라이언트 정보 발급
+     * @param partnerEntity 클라이언트 발급 대상 사용자 객체
      */
     public void setPublishedClientInfo(PartnerEntity partnerEntity){
         this.clientId = UUID.randomUUID().toString();
@@ -79,7 +79,6 @@ public class ClientEntity extends MetaEntity {
         this.refreshTokenValidity = 86400; // 24시간
 
         partnerEntity.publishedClientInfo();
-        partnerEntity.setClientEntity(this);
         this.partnerEntity = partnerEntity;
     }
 }

--- a/AuthorizationServer/src/main/java/io/example/authorization/domain/entity/partner/PartnerEntity.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/domain/entity/partner/PartnerEntity.java
@@ -49,7 +49,7 @@ public class PartnerEntity extends MetaEntity {
     @Enumerated(EnumType.STRING)
     private PartnerStatus partnerStatus; // 파트너 상태
 
-    @OneToOne(mappedBy = "partnerEntity")
+    @OneToOne(mappedBy = "partnerEntity", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private ClientEntity clientEntity;
 
     public void signUp(){

--- a/AuthorizationServer/src/test/java/io/example/authorization/config/AuthorizationConfigTest.java
+++ b/AuthorizationServer/src/test/java/io/example/authorization/config/AuthorizationConfigTest.java
@@ -4,6 +4,7 @@ import io.example.authorization.common.BaseTest;
 import io.example.authorization.domain.dto.request.partner.CreatePartner;
 import io.example.authorization.domain.entity.partner.PartnerEntity;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.modelmapper.ModelMapper;
@@ -34,7 +35,8 @@ class AuthorizationConfigTest extends BaseTest{
     private MockMvc mockMvc;
 
     @Test
-    @DisplayName("인증 토큰 발급 : Password Type의 인증 토큰 발급")
+    @DisplayName("인증 토큰 발급 : InMemory환경의 Password Type의 인증 토큰 발급")
+    @Disabled
     public void issuedAccessTokenToInMemoryUser() throws Exception {
         //given
         String urlTemplate = "/oauth/token";

--- a/AuthorizationServer/src/test/java/io/example/authorization/service/PartnerServiceTest.java
+++ b/AuthorizationServer/src/test/java/io/example/authorization/service/PartnerServiceTest.java
@@ -2,6 +2,7 @@ package io.example.authorization.service;
 
 import io.example.authorization.common.BaseTest;
 import io.example.authorization.domain.dto.request.partner.CreatePartner;
+import io.example.authorization.domain.dto.request.partner.IssueClient;
 import io.example.authorization.domain.dto.response.common.ProcessingResult;
 import io.example.authorization.domain.entity.partner.PartnerEntity;
 import io.example.authorization.domain.entity.partner.PartnerRole;
@@ -67,5 +68,29 @@ class PartnerServiceTest extends BaseTest {
         // Then
         assertThat(userDetails.getUsername()).isEqualTo(savedPartnerId);
         assertThat(userDetails.getPassword()).isEqualTo(savedPartnerEntity.getPartnerPassword());
+    }
+
+
+    @Test
+    @DisplayName("DB에 존재하는 사용자 정보에 Client 정보 생성")
+    public void setClientInfoToPartner() {
+        // Given
+        CreatePartner createPartner = this.partnerGenerator.createPartner();
+        ProcessingResult createPartnerProcessingResult = this.partnerService.savePartner(createPartner);
+        assertThat(createPartnerProcessingResult.isSuccess()).isTrue();
+
+        // Given
+        PartnerEntity savedPartnerEntity = (PartnerEntity) createPartnerProcessingResult.getData();
+        String resourceIds = "NAVER";
+
+        IssueClient issueClient = new IssueClient();
+        issueClient.setPartnerNo(savedPartnerEntity.getPartnerNo());
+        issueClient.setResourceIds(resourceIds);
+
+        // When
+        ProcessingResult createClientPartnerProcessingResult = partnerService.saveClient(issueClient);
+
+        // Then
+        assertThat(createClientPartnerProcessingResult.isSuccess()).isTrue();
     }
 }

--- a/AuthorizationServer/src/test/java/io/example/authorization/service/PartnerServiceTest.java
+++ b/AuthorizationServer/src/test/java/io/example/authorization/service/PartnerServiceTest.java
@@ -1,5 +1,6 @@
 package io.example.authorization.service;
 
+import io.example.authorization.common.BaseTest;
 import io.example.authorization.domain.dto.request.partner.CreatePartner;
 import io.example.authorization.domain.dto.response.common.ProcessingResult;
 import io.example.authorization.domain.entity.partner.PartnerEntity;
@@ -9,28 +10,21 @@ import io.example.authorization.generator.PartnerGenerator;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.test.context.ActiveProfiles;
 
 import javax.annotation.Resource;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 /**
  * @author : choi-ys
  * @date : 2021/02/19 12:20 오후
  * @Content : 사용자 계정 관련 TC
  */
-@SpringBootTest(webEnvironment = RANDOM_PORT)
 @DisplayName("Partner Service Test")
-@ActiveProfiles("test")
-@Import(PartnerGenerator.class)
-class PartnerServiceTest {
+class PartnerServiceTest extends BaseTest {
 
     @Resource
     protected  PartnerGenerator partnerGenerator;


### PR DESCRIPTION
 - 불필요 TC 실행 제외 처리 및 BaseTest 미 상속 TC Annotations 설정 수정
 - 클라이언트 발급 요청 객체 설계 및 정의
 - 특정 사용자에 클라이언트 정보 발급 처리 로직 구현
   - 요청 사용자 정보 존재 여부 확인
   - 클라이언트 정보 발급 여부 확인(현재 컨셉 = 1:1)
   - 클라이언트 정보 생성 시 입력값 혹은 초기값으로 결정되어야 하는 항목들의 값 설정
   - 클라이언트 정보 DB 저장
   - TEST : 특정 사용자의 클라이언트 정보 생성 여부 확인