### PR TITLE
[2021-03-04][Authorization]용석:DB의 사용자 정보와 클라이언트 정보를 이용한 인증 토큰 발급

### DIFF
--- a/AuthorizationServer/src/main/java/io/example/authorization/config/AuthorizationConfig.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/config/AuthorizationConfig.java
@@ -1,5 +1,6 @@
 package io.example.authorization.config;
 
+import io.example.authorization.service.PartnerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -22,15 +23,12 @@ public class AuthorizationConfig extends AuthorizationServerConfigurerAdapter {
     // application.yml에 등록된 database 설정 및 접속 정보
     private final DataSource dataSource;
 
+    private final PartnerService partnerService;
+
     // 인증 Token 발급/갱신에 필요한 Clinet정보를 코드로 설정
     @Override
     public void configure(ClientDetailsServiceConfigurer clients) throws Exception {
-        clients.inMemory()
-                .withClient("testClientId")
-                .secret("{noop}testClientSecret")
-                .authorizedGrantTypes("password", "refresh_token")
-                .scopes("read")
-        ;
+        clients.withClientDetails(partnerService);
     }
 
     /**

--- a/AuthorizationServer/src/main/java/io/example/authorization/domain/entity/partner/ClientEntity.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/domain/entity/partner/ClientEntity.java
@@ -3,8 +3,11 @@ package io.example.authorization.domain.entity.partner;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.example.authorization.domain.entity.common.MetaEntity;
 import lombok.*;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.provider.ClientDetails;
 
 import javax.persistence.*;
 import java.util.*;
@@ -18,7 +21,7 @@ import java.util.*;
         )
 @Getter @Setter
 @Builder @NoArgsConstructor @AllArgsConstructor
-public class ClientEntity extends MetaEntity {
+public class ClientEntity extends MetaEntity implements ClientDetails {
 
     @Id
     @Column(name = "client_id")
@@ -80,5 +83,76 @@ public class ClientEntity extends MetaEntity {
 
         partnerEntity.publishedClientInfo();
         this.partnerEntity = partnerEntity;
+    }
+
+    @Override
+    public String getClientId() {
+        return clientId;
+    }
+    @Override
+    public Set<String> getResourceIds() {
+        if (resourceIds == null) return null;
+        String[] s = resourceIds.split(",");
+        return new HashSet<>(Arrays.asList(s));
+    }
+
+    @Override
+    public boolean isSecretRequired() {
+        return clientSecret != null;
+    }
+
+    @Override
+    public String getClientSecret() {
+        return clientSecret;
+    }
+
+    @Override
+    public boolean isScoped() {
+        return scope != null;
+    }
+
+    @Override
+    public Set<String> getScope() {
+        if (scope == null) return null;
+        String[] s = scope.split(",");
+        return new HashSet<>(Arrays.asList(s));
+    }
+
+    @Override
+    public Set<String> getAuthorizedGrantTypes() {
+        if (authorizedGrantTypes == null) return null;
+        String[] s = authorizedGrantTypes.split(",");
+        return new HashSet<>(Arrays.asList(s));
+    }
+
+    @Override
+    public Set<String> getRegisteredRedirectUri() {
+        return null;
+    }
+
+    @Override
+    public Collection<GrantedAuthority> getAuthorities() {
+        if (authorities == null) return new ArrayList<>();
+        return AuthorityUtils.createAuthorityList(authorities.split(","));
+    }
+
+    @Override
+    public Integer getAccessTokenValiditySeconds() {
+        return accessTokenValidity;
+    }
+
+    @Override
+    public Integer getRefreshTokenValiditySeconds() {
+        return refreshTokenValidity;
+    }
+
+    @Override
+    public boolean isAutoApprove(String scope) {
+        return autoApprove;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalInformation() {
+        return null;
     }
 }

--- a/AuthorizationServer/src/main/java/io/example/authorization/service/PartnerService.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/service/PartnerService.java
@@ -19,6 +19,9 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.provider.ClientDetails;
+import org.springframework.security.oauth2.provider.ClientDetailsService;
+import org.springframework.security.oauth2.provider.ClientRegistrationException;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
@@ -36,7 +39,7 @@ import static io.example.authorization.service.common.CommonResult.serverError;
 **/
 @Service
 @RequiredArgsConstructor
-public class PartnerService implements UserDetailsService {
+public class PartnerService implements UserDetailsService, ClientDetailsService {
 
     private final PartnerRepository partnerRepository;
     private final ClientRepository clientRepository;
@@ -151,5 +154,13 @@ public class PartnerService implements UserDetailsService {
         } catch (Exception e) {
             return serverError(e);
         }
+    }
+
+    @Override
+    public ClientDetails loadClientByClientId(String clientId) throws ClientRegistrationException {
+        ClientEntity clientEntity = this.clientRepository.findById(clientId)
+                .orElseThrow(() -> new UsernameNotFoundException(clientId))
+                ;
+        return clientEntity;
     }
 }

--- a/AuthorizationServer/src/test/java/io/example/authorization/common/BaseTest.java
+++ b/AuthorizationServer/src/test/java/io/example/authorization/common/BaseTest.java
@@ -3,6 +3,7 @@ package io.example.authorization.common;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.example.authorization.generator.PartnerGenerator;
 import io.example.authorization.repository.PartnerRepository;
+import io.example.authorization.service.PartnerService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
@@ -40,6 +41,9 @@ public class BaseTest {
 
     @Autowired
     protected PartnerRepository partnerRepository;
+
+    @Autowired
+    protected PartnerService partnerService;
 
     @Resource
     protected  PartnerGenerator partnerGenerator;

--- a/AuthorizationServer/src/test/java/io/example/authorization/config/AuthorizationConfigTest.java
+++ b/AuthorizationServer/src/test/java/io/example/authorization/config/AuthorizationConfigTest.java
@@ -2,6 +2,9 @@ package io.example.authorization.config;
 
 import io.example.authorization.common.BaseTest;
 import io.example.authorization.domain.dto.request.partner.CreatePartner;
+import io.example.authorization.domain.dto.request.partner.IssueClient;
+import io.example.authorization.domain.dto.response.common.ProcessingResult;
+import io.example.authorization.domain.entity.partner.ClientEntity;
 import io.example.authorization.domain.entity.partner.PartnerEntity;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Disabled;
@@ -14,6 +17,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -35,7 +39,7 @@ class AuthorizationConfigTest extends BaseTest{
     private MockMvc mockMvc;
 
     @Test
-    @DisplayName("인증 토큰 발급 : InMemory환경의 Password Type의 인증 토큰 발급")
+    @DisplayName("인증 토큰 발급 : InMemory환경의 사용자 정보와 클라이언트 정보를 이용한 Password Type의 인증 토큰 발급")
     @Disabled
     public void issuedAccessTokenToInMemoryUser() throws Exception {
         //given
@@ -67,7 +71,8 @@ class AuthorizationConfigTest extends BaseTest{
     }
 
     @Test
-    @DisplayName("인증 토큰 발급 : DB의 인증된 사용자 정보를 이용한 Token 발급")
+    @DisplayName("인증 토큰 발급 : DB의 인증된 사용자 정보와 InMemory의 클라이언트 정보를 이용한 Token 발급")
+    @Disabled
     public void issuedAccessTokenToDatabaseUser() throws Exception {
         //given
         CreatePartner createPartner = this.partnerGenerator.createPartner();
@@ -95,6 +100,54 @@ class AuthorizationConfigTest extends BaseTest{
         );
 
         //then
+        resultActions.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("access_token").exists())
+                .andExpect(jsonPath("token_type").exists())
+                .andExpect(jsonPath("refresh_token").exists())
+                .andExpect(jsonPath("expires_in").exists())
+                .andExpect(jsonPath("scope").exists())
+        ;
+    }
+
+    @Test
+    @DisplayName("인증 토큰 발급 : DB의 인증된 사용자 정보와 클라이언트 정보를 이용한 Token 발급")
+    public void issuedAccessTokenToDatabaseUserWithDatabaseClient() throws Exception {
+        // Given : 토큰 발급 대상 사용자 정보 생성
+        CreatePartner createPartner = this.partnerGenerator.createPartner();
+        ProcessingResult createPartnerProcessingResult = this.partnerService.savePartner(createPartner);
+        assertThat(createPartnerProcessingResult.isSuccess()).isTrue();
+
+        // Given : 생성된 사용자에 클라이언트 정보 발급
+        PartnerEntity savedPartnerEntity = (PartnerEntity) createPartnerProcessingResult.getData();
+        String resourceIds = "NAVER";
+        IssueClient issueClient = new IssueClient();
+        issueClient.setPartnerNo(savedPartnerEntity.getPartnerNo());
+        issueClient.setResourceIds(resourceIds);
+
+        ProcessingResult issueClientProcessingResult = this.partnerService.saveClient(issueClient);
+        assertThat(issueClientProcessingResult.isSuccess()).isTrue();
+
+        // Given : 토큰 발급 요청에 필요한 사용자 정보와 클라이언트 정보 설정
+        ClientEntity clientEntity = (ClientEntity) issueClientProcessingResult.getData();
+
+        String urlTemplate = "/oauth/token";
+        String clientId = clientEntity.getClientId();
+        String clientSecret = clientEntity.getClientId();
+        String username = createPartner.getPartnerId();
+        String password = createPartner.getPartnerPassword();
+
+        // When
+        ResultActions resultActions = this.mockMvc.perform(post(urlTemplate)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .with(httpBasic(clientId, clientSecret))
+                .param("username", username)
+                .param("password", password)
+                .param("grant_type", "password")
+        );
+
+        // Then
         resultActions.andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("access_token").exists())


### PR DESCRIPTION
- 인증 토큰에 대한 클라이언트 정보를 관리하는 ClientDetailsServiceConfigurer 설정 수정
  - 목표 : InMemory에 코드로 명시된 클라이언트 정보를 특정 사용자에게 부여한 DB의 클라이언트 정보로 설정 변경
  - 구현방법 : 특정 사용자에게 발급 후 DB에 저장된 클라이언트 정보 조회 시 ClientDetailsServiceConfigurer에 설정 가능한 객체인 ClientDetails로 변환 하기 위해 Spring Security에서 제공하는 ClientDetailsService의 loadClientByClientId 구현
  - 효과 : loadClientByClientId 구현을 통해 현재 서비스에서 설계한 클라이언트 정보를 표현하는 ClientEntity객체를 조회 하여 ClientDetailsServiceConfigurer에 설정 가능한 객체인 ClientDetails로 변환