### PR TITLE
[2021-03-05][Authorization]용석:Refresh Token을 이용한 Access Token갱신

### DIFF
--- a/AuthorizationServer/src/main/java/io/example/authorization/config/AuthorizationConfig.java
+++ b/AuthorizationServer/src/main/java/io/example/authorization/config/AuthorizationConfig.java
@@ -35,6 +35,7 @@ public class AuthorizationConfig extends AuthorizationServerConfigurerAdapter {
      * 인증 토큰 발급/갱신 요청 처리 부
      *  - 인증 토큰 발급 시 필요한 인증된 사용자 정보 등록
      *  - 발급 토큰 정보 관리하는 TokenStore에 Datasource 정보 등록
+     *  endpoint URL : AuthorizationServerSecurityConfiguration
      * @param endpoints
      * @throws Exception
      */
@@ -42,6 +43,8 @@ public class AuthorizationConfig extends AuthorizationServerConfigurerAdapter {
     public void configure(AuthorizationServerEndpointsConfigurer endpoints) throws Exception {
         endpoints.authenticationManager(authenticationManager) // Account 인증 정보를 소유한 Bean
                 .tokenStore(new JdbcTokenStore(dataSource)) // application에 명시된 dataSource를 tokenStore로 설정
+                .userDetailsService(partnerService) // Refresh Token을 이용한 Access Token갱신 시 인증된 사용자 여부 검사를 위한 UserDetailsService 구현체 설정
+                .reuseRefreshTokens(false) //  Refresh Token을 이용한 Access Token갱신 시 Refresh Token 만료 처리 설정
         ;
     }
 }


### PR DESCRIPTION
 - Refresh Token을 이용한 Access Token갱신 처리에 필요한 설정 추가
   - 갱신 요청 시 인증된 사용자 여부 확인을 위한 AuthorizationServerEndpointsConfigurer에 UserDetailsService 설정 추가
   - 갱신 요청 시 Refresh Token만료 설정을 위한 reuseRefreshTokens(false) 설정 추가

 - TEST : Refresh Token을 이용한 Access Token 갱신